### PR TITLE
Fixes PTV-609 & PTV-610

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,8 @@ MAINTAINER KBase Developer
 # any required dependencies for your module.
 
 # RUN apt-get update
-RUN cpanm -i Config::IniFiles
+RUN cpanm -i Config::IniFiles \
+    && cpanm -n Devel::Cover
 
 # -----------------------------------------
 

--- a/lib/Bio/KBase/ObjectAPI/KBaseFBA/FBAModel.pm
+++ b/lib/Bio/KBase/ObjectAPI/KBaseFBA/FBAModel.pm
@@ -2281,15 +2281,22 @@ sub translate_model {
 			features => $extra_features
 		});
 	}
+	$self->translate_to_localrefs();
 	return {};
 }
 
 sub translate_to_localrefs {
 	my $self = shift;
+	my %seen = ();
 	my $compartments = $self->modelcompartments();
     for (my $i=0; $i < @{$compartments}; $i++) {
 		if ($compartments->[$i]->compartment_ref() =~ m/\/([^\/]+)$/) {
-    		$compartments->[$i]->compartment_ref("~/template/compartments/id/".$1);
+			if (! $seen{ $1 }++) {
+				$compartments->[$i]->compartment_ref("~/template/compartments/id/" . $1);
+			} else {
+				print "Removeing duplicated compartment: ".$compartments->[$i]->label()."\n";
+				$self->remove("modelcompartments",$compartments->[$i]);
+			}
 		}
     }
 	my $compounds = $self->modelcompounds();

--- a/lib/Bio/KBase/ObjectAPI/KBaseFBA/FBAModel.pm
+++ b/lib/Bio/KBase/ObjectAPI/KBaseFBA/FBAModel.pm
@@ -2166,7 +2166,6 @@ sub translate_model {
 	}, @_);
 	my $protcomp = $args->{proteome_comparison};
 	my $genome = $self->genome();
-	print $genome->id();
 	my $ftrs = $genome->features();
 	my $numftrs = @{$ftrs};
 	my $ftrhash;

--- a/lib/Bio/KBase/ObjectAPI/functions.pm
+++ b/lib/Bio/KBase/ObjectAPI/functions.pm
@@ -891,6 +891,7 @@ sub func_propagate_model_to_new_genome {
 	my $rxns = $source_model->modelreactions();
 	my $model = $source_model->cloneObject();
 	$model->parent($source_model->parent());
+	$model->id($params->{fbamodel_output_id});
 	$handler->util_log("Retrieving proteome comparison.");
 	my $protcomp = $handler->util_get_object(Bio::KBase::utilities::buildref($params->{proteincomparison_id},$params->{proteincomparison_workspace}));
 	$handler->util_log("Translating model.");

--- a/test/new_fba_tools_tests.pl
+++ b/test/new_fba_tools_tests.pl
@@ -371,28 +371,7 @@ lives_ok{
 			workspace_name => "chenry:narrative_1504151898593"
         })
     } 'export model as tsv';
-=cut
-# export_model_as_excel_file
-lives_ok{
-        $impl->export_model_as_excel_file({
-           input_ref => "chenry:narrative_1504151898593/test_model_minimal"
-        })
-    } 'export model as excel';
-		
-# export_model_as_tsv_file
-lives_ok{
-        $impl->export_model_as_tsv_file({
-           input_ref => "chenry:narrative_1504151898593/test_model_minimal"
-        })
-    } 'export model as tsv';
 
-# export_model_as_sbml_file
-lives_ok{
-        $impl->export_model_as_sbml_file({
-           input_ref => "chenry:narrative_1504151898593/test_model_minimal"
-        })
-    } 'export model as sbml';
-=cut
 # fba_to_excel_file
 lives_ok{
         $impl->fba_to_excel_file({
@@ -408,21 +387,7 @@ lives_ok{
 			workspace_name => "chenry:narrative_1504151898593"
         })
     } 'export fba as tsv';
-=cut
-# export_fba_as_excel_file
-lives_ok{
-        $impl->export_fba_as_excel_file({
-           input_ref => "chenry:narrative_1504151898593/test_minimal_fba"
-        })
-    } 'export fba as excel';
 
-# export_fba_as_tsv_file
-lives_ok{
-        $impl->export_fba_as_tsv_file({
-           input_ref => "chenry:narrative_1504151898593/test_minimal_fba"
-        })
-    } 'export fba as tsv';
-=cut
 # tsv_file_to_media
 lives_ok{
         $impl->tsv_file_to_media({
@@ -472,21 +437,7 @@ lives_ok{
 			workspace_name => get_ws_name()
         })
     } 'media to excel file';
-=cut
-# export_media_as_excel_file
-lives_ok{
-        $impl->export_media_as_excel_file({
-            input_ref => get_ws_name()."/tsv_media"
-        })
-    } 'export media as excel';
 
-# export_media_as_tsv_file
-lives_ok{
-        $impl->export_media_as_tsv_file({
-            input_ref => get_ws_name()."/tsv_media"
-        })
-    } 'export media as tsv';
-=cut
 # tsv_file_to_phenotype_set
 lives_ok{
         $impl->tsv_file_to_phenotype_set({
@@ -505,14 +456,7 @@ lives_ok{
 			workspace_name => "chenry:narrative_1504151898593"
         })
     } 'export phenotypes as tsv';
-=cut
-# export_phenotype_set_as_tsv_file
-lives_ok{
-        $impl->export_phenotype_set_as_tsv_file({
-			input_ref => "chenry:narrative_1504151898593/SB2B_biolog_data"
-        })
-    } 'export phenotypes as tsv';
-=cut
+
 # phenotype_simulation_set_to_excel_file
 lives_ok{
         $impl->phenotype_simulation_set_to_excel_file({
@@ -528,7 +472,74 @@ lives_ok{
 			workspace_name => "jjeffryes:narrative_1502586048308"
         })
     } 'phenosim to tsv';
+
+# bulk_export_objects
+lives_ok{
+        $impl->bulk_export_objects({
+            refs => [ "7601/20/9", "7601/18/9" ],
+	        workspace => "jjeffryes:narrative_1502586048308",
+	        all_media => 1,
+	        media_format => "excel"
+        })
+    } 'bulk export of modeling objects';
+
 =cut
+# export_model_as_excel_file
+lives_ok{
+        $impl->export_model_as_excel_file({
+           input_ref => "chenry:narrative_1504151898593/test_model_minimal"
+        })
+    } 'export model as excel';
+
+# export_model_as_tsv_file
+lives_ok{
+        $impl->export_model_as_tsv_file({
+           input_ref => "chenry:narrative_1504151898593/test_model_minimal"
+        })
+    } 'export model as tsv';
+
+# export_model_as_sbml_file
+lives_ok{
+        $impl->export_model_as_sbml_file({
+           input_ref => "chenry:narrative_1504151898593/test_model_minimal"
+        })
+    } 'export model as sbml';
+
+# export_fba_as_excel_file
+lives_ok{
+        $impl->export_fba_as_excel_file({
+           input_ref => "chenry:narrative_1504151898593/test_minimal_fba"
+        })
+    } 'export fba as excel';
+
+# export_fba_as_tsv_file
+lives_ok{
+        $impl->export_fba_as_tsv_file({
+           input_ref => "chenry:narrative_1504151898593/test_minimal_fba"
+        })
+    } 'export fba as tsv';
+
+# export_media_as_excel_file
+lives_ok{
+        $impl->export_media_as_excel_file({
+            input_ref => get_ws_name()."/tsv_media"
+        })
+    } 'export media as excel';
+
+# export_media_as_tsv_file
+lives_ok{
+        $impl->export_media_as_tsv_file({
+            input_ref => get_ws_name()."/tsv_media"
+        })
+    } 'export media as tsv';
+
+# export_phenotype_set_as_tsv_file
+lives_ok{
+        $impl->export_phenotype_set_as_tsv_file({
+			input_ref => "chenry:narrative_1504151898593/SB2B_biolog_data"
+        })
+    } 'export phenotypes as tsv';
+
 # export_phenotype_simulation_set_as_excel_file
 lives_ok{
         $impl->export_phenotype_simulation_set_as_excel_file({
@@ -543,15 +554,6 @@ lives_ok{
         })
     } 'export phenotype sim set as tsv';
 =cut
-# bulk_export_objects
-lives_ok{
-        $impl->bulk_export_objects({
-            refs => [ "7601/20/9", "7601/18/9" ],
-	        workspace => "jjeffryes:narrative_1502586048308",
-	        all_media => 1,
-	        media_format => "excel"
-        })
-    } 'bulk export of modeling objects';
 
 done_testing();
 

--- a/test/new_fba_tools_tests.pl
+++ b/test/new_fba_tools_tests.pl
@@ -90,7 +90,7 @@ lives_ok{
             media_id                    => "Carbon-D-Glucose",
             media_workspace             => "chenry:narrative_1504151898593",
             fbamodel_output_id          => "test_propagated_model",
-            workspace                   => "chenry:narrative_1504151898593",
+            workspace                   => get_ws_name(),
             keep_nogene_rxn             => 1,
             gapfill_model               => 0,
             custom_bound_list           => [],

--- a/test/new_fba_tools_tests.pl
+++ b/test/new_fba_tools_tests.pl
@@ -31,6 +31,7 @@ sub get_ws_name {
     return $ws_name;
 }
 #=head
+
 # build_metabolic_model
 lives_ok{
         $impl->build_metabolic_model({
@@ -89,9 +90,9 @@ lives_ok{
             media_id                    => "Carbon-D-Glucose",
             media_workspace             => "chenry:narrative_1504151898593",
             fbamodel_output_id          => "test_propagated_model",
-            workspace                   => get_ws_name(),
+            workspace                   => "chenry:narrative_1504151898593",
             keep_nogene_rxn             => 1,
-            gapfill_model               => 1,
+            gapfill_model               => 0,
             custom_bound_list           => [],
             media_supplement_list       => "",
             minimum_target_flux         => 0.1,
@@ -147,14 +148,125 @@ lives_ok{
     } "build_multiple_metabolic_models";
 
 # compare_fba_solutions
+lives_ok{
+        $impl->compare_fba_solutions({
+            fba_id_list => ["8248/168/1", "8248/166/1"],
+			fbacomparison_output_id => "fba_comparison",
+			workspace => "chenry:narrative_1504151898593",
+        })
+    } "compare_fba_solutions";
 
 # merge_metabolic_models_into_community_model
+lives_ok{
+        $impl->merge_metabolic_models_into_community_model({
+            fbamodel_id_list => ["8248/162/23", "8248/15/1"],
+			fbamodel_output_id => "Community_model",
+			workspace => "chenry:narrative_1504151898593",
+			mixed_bag_model => 1
+        })
+    } "merge_metabolic_models_into_community_model";
 
 # compare_flux_with_expression
 
 # edit_metabolic_model
+lives_ok{
+        $impl->edit_metabolic_model({
+            workspace => "chenry:narrative_1504151898593",
+			fbamodel_id => "test_model",
+	    	compounds_to_add => [{
+	    		add_compound_id => "testcompound_c0",
+                add_compartment_id => "c0",
+                add_compound_name => "test_compound_name",
+                add_compound_charge => 0,
+                add_compound_formula => "C4H4"
+	    	},{
+	    		add_compound_id => "testcompound_e0",
+                add_compartment_id => "e0",
+                add_compound_name => "test_compound_name",
+                add_compound_charge => 0,
+                add_compound_formula => "C4H4"
+	    	}],
+	    	compounds_to_change => [{
+	    		compound_id => "cpd00036_c0",
+                compound_name => "testname",
+                compound_charge => 0,
+                compound_formula => "C4H4"
+	    	}],
+	    	biomasses_to_add => [{
+	    		biomass_name => "TestBiomass",
+				biomass_dna => 0,
+				biomass_rna => 0,
+				biomass_protein => 1,
+				biomass_cellwall => 0,
+				biomass_lipid => 0,
+				biomass_cofactor => 0,
+				biomass_energy => 0
+			}],
+	    	biomass_compounds_to_change => [{
+	    		biomass_id => "bio1",
+                biomass_compound_id => "cpd00220_c0",
+				biomass_coefficient => 0
+	    	},{
+	    		biomass_id => "bio1",
+                biomass_compound_id => "cpd15352_c0",
+				biomass_coefficient => -0.004
+	    	}],
+	    	reactions_to_remove => [
+	    		"rxn00016_c0"
+	    	],
+	    	reactions_to_change => [{
+	    		change_reaction_id => "rxn00015_c0",
+                change_reaction_name => "testname",
+                change_reaction_direction => "<",
+				change_reaction_gpr => "(fig|211586.9.peg.3166 and fig|211586.9.peg.3640)"
+	    	}],
+	    	reactions_to_add => [{
+	    		add_reaction_id => "rxn00021_c0",
+                reaction_compartment_id => "c0",
+                add_reaction_name => undef,
+                add_reaction_direction => undef,
+				add_reaction_gpr => "fig|211586.9.peg.3166",
+	    	},{
+	    		add_reaction_id => "testcustomreaction",
+                reaction_compartment_id => "c0",
+                add_reaction_name => "test_transporter",
+                add_reaction_direction => ">",
+				add_reaction_gpr => "fig|211586.9.peg.3166",
+	    	}],
+	    	edit_compound_stoichiometry => [{
+	    		stoich_reaction_id => "testcustomreaction_c0",
+                stoich_compound_id => "testcompound_c0",
+                stoich_coefficient =>  -1
+	    	},{
+	    		stoich_reaction_id => "testcustomreaction_c0",
+                stoich_compound_id => "testcompound_e0",
+                stoich_coefficient => 1
+	    	},{
+	    		stoich_reaction_id => "rxn00022_c0",
+                stoich_compound_id => "cpd00179_c0",
+                stoich_coefficient => 0
+	    	}],
+	    	fbamodel_output_id => "edited_model"
+        })
+    }, "Edit Model";
 
 # edit_media
+lives_ok{
+        $impl->edit_media({
+            workspace => "chenry:narrative_1504151898593",
+			media_output_id => "edited_media",
+			media_id => "BaseMedia",
+	    	compounds_to_remove => "cpd00204",
+	    	compounds_to_change => [{change_id => "cpd00001",change_concentration => 0.1,change_minflux => -100,change_maxflux => 1}],
+	    	compounds_to_add => [{add_id => "Acetate",add_concentration => 0.1,add_minflux => -100,add_maxflux => 1}],
+	    	pH_data => "8",
+	    	temperature => 303,
+	    	source_id => "edit_media_test_source_id",
+	    	source => "edit_media_test_source",
+	    	type => "test",
+	    	isDefined => 1
+        })
+    } "Edit Media";
 
 # excel_file_to_model
 lives_ok{


### PR DESCRIPTION
This solves the duplicate id issue with compare model (which is caused by propagate model) and the duplicated compartments issue. The fix involves converting all refs in the model to to local refs (~/templates/...) and this step should likely be repeated with other apps that produce a metabolic model