### PR TITLE
PTV-699

### DIFF
--- a/lib/Bio/KBase/ObjectAPI/KBaseFBA/FBAModel.pm
+++ b/lib/Bio/KBase/ObjectAPI/KBaseFBA/FBAModel.pm
@@ -1938,6 +1938,9 @@ sub edit_metabolic_model {
 				}
 			}
 		}
+		if (!defined $params->{compounds_to_add}->[$i]->{add_compartment_id}){
+			Bio::KBase::utilities::error("Must specify a compartment id for new compounds");
+		}
 		my $mdlcpd = $self->add("modelcompounds",{
 			id => $params->{compounds_to_add}->[$i]->{add_compound_id}."_".$params->{compounds_to_add}->[$i]->{add_compartment_id},
 			modelcompartment_ref => "~/modelcompartments/id/".$params->{compounds_to_add}->[$i]->{add_compartment_id},
@@ -2075,6 +2078,9 @@ sub edit_metabolic_model {
 			$rxnobj = $self->template()->biochemistry()->getObject("reactions",$rxnadd->{add_reaction_id});
 		}
 		my $rxnref = "~/template/reactions/id/rxn00000_c";
+		if (!defined $rxnadd->{reaction_compartment_id}){
+			Bio::KBase::utilities::error("Must specify a compartment id for new reactions");
+		}
 		if (defined($rxnobj)) {
 			if (!defined($rxnadd->{add_reaction_name}) || $rxnadd->{add_reaction_name} eq "") {
 				$rxnadd->{add_reaction_name} = $rxnobj->name();

--- a/ui/narrative/methods/edit_media/spec.json
+++ b/ui/narrative/methods/edit_media/spec.json
@@ -174,7 +174,7 @@
          ],
          "advanced" : false,
          "field_type" : "text",
-         "optional" : true,
+         "optional" : false,
          "allow_multiple" : false
       },
       {
@@ -187,7 +187,7 @@
          ],
          "advanced" : false,
          "field_type" : "text",
-         "optional" : true,
+         "optional" : false,
          "allow_multiple" : false
       },
       {
@@ -200,7 +200,7 @@
          ],
          "advanced" : false,
          "field_type" : "text",
-         "optional" : true,
+         "optional" : false,
          "allow_multiple" : false
       },
       {
@@ -213,7 +213,7 @@
          ],
          "advanced" : false,
          "field_type" : "text",
-         "optional" : true,
+         "optional" : false,
          "allow_multiple" : false
       },
       {

--- a/ui/narrative/methods/edit_metabolic_model/spec.json
+++ b/ui/narrative/methods/edit_metabolic_model/spec.json
@@ -140,7 +140,7 @@
 			"id" : "add_compound_id",
 			"field_type" : "text",
 			"allow_multiple" : false,
-			"optional" : true,
+			"optional" : false,
 			"text_options" : {
 				"valid_ws_types" : []
 			}
@@ -151,7 +151,7 @@
 			"id" : "add_compound_name",
 			"field_type" : "text",
 			"allow_multiple" : false,
-			"optional" : true,
+			"optional" : false,
 			"text_options" : {
 				"valid_ws_types" : []
 			}
@@ -164,7 +164,7 @@
 			"default_values" : [""],
 			"advanced" : false,
 			"field_type" : "text",
-			"optional" : true,
+			"optional" : false,
 			"allow_multiple" : false
 		},
 		{
@@ -173,7 +173,7 @@
 			"id" : "add_compound_formula",
 			"field_type" : "text",
 			"allow_multiple" : false,
-			"optional" : true,
+			"optional" : false,
 			"text_options" : {
 				"valid_ws_types" : []
 			}

--- a/ui/narrative/methods/edit_metabolic_model/spec.json
+++ b/ui/narrative/methods/edit_metabolic_model/spec.json
@@ -540,13 +540,13 @@
 			"id" : "add_reaction_id",
 			"field_type" : "text",
 			"allow_multiple" : false,
-			"optional" : true,
+			"optional" : false,
 			"text_options" : {
 				"valid_ws_types" : []
 			}
 		},
 		{
-         "optional" : true,
+         "optional" : false,
          "allow_multiple" : false,
          "field_type" : "dropdown",
          "dropdown_options" : {
@@ -573,7 +573,7 @@
          },
          "id" : "add_reaction_direction",
          "advanced" : false,
-         "default_values" : [""],
+         "default_values" : ["="],
          "text_options" : {
             "valid_ws_types" : []
          }
@@ -584,7 +584,7 @@
 			"id" : "add_reaction_name",
 			"field_type" : "text",
 			"allow_multiple" : false,
-			"optional" : true,
+			"optional" : false,
 			"text_options" : {
 				"valid_ws_types" : []
 			}
@@ -633,7 +633,7 @@
 		},
 		{
 			"allow_multiple" : false,
-			"optional" : true,
+			"optional" : false,
 			"field_type" : "textsubdata",
 			"id" : "reaction_compartment_id",
 			"advanced" : false,
@@ -664,7 +664,7 @@
 		},
 		{
 			"allow_multiple" : false,
-			"optional" : true,
+			"optional" : false,
 			"field_type" : "textsubdata",
 			"id" : "stoich_reaction_id",
 			"advanced" : false,
@@ -695,7 +695,7 @@
 		},
 		{
 			"allow_multiple" : false,
-			"optional" : true,
+			"optional" : false,
 			"field_type" : "textsubdata",
 			"id" : "stoich_compound_id",
 			"advanced" : false,
@@ -732,7 +732,7 @@
 			"default_values" : [""],
 			"advanced" : false,
 			"field_type" : "text",
-			"optional" : true,
+			"optional" : false,
 			"allow_multiple" : false
 		}
 	],


### PR DESCRIPTION
This prevents users from corrupting a model by adding a compound or reaction to a model without compartment. Most of these parameters revert to a default in the backend but as that's not transparent to the user, I think it's better to make them required.

I also added checks to make sure compartments are set in edit metabolic model which error out on failure

 