### PR TITLE
Fixing bug in translating local reaction refs

### DIFF
--- a/lib/Bio/KBase/ObjectAPI/KBaseFBA/FBAModel.pm
+++ b/lib/Bio/KBase/ObjectAPI/KBaseFBA/FBAModel.pm
@@ -2411,7 +2411,7 @@ sub translate_to_localrefs {
 		my $array = [split(/_/,$reactions->[$i]->id())];
 	 	my $comp = pop(@{$array});
 	 	$comp =~ s/\d+//;
-		if ($reactions->[$i]->reaction_ref() =~ m/\/([^\/]+)$/) {
+		if ($reactions->[$i]->reaction_ref() =~ m/\/([^\/]+?)(_[^\/])?$/) {
 			$reactions->[$i]->reaction_ref("~/template/reactions/id/".$1."_".$comp);
 		}
 		my $prots = $reactions->[$i]->modelReactionProteins();


### PR DESCRIPTION
This was tested with in a local dev_container with the reconstruction of a plant model.