### PR TITLE
fix Phenotype Class in export to TSV

### DIFF
--- a/lib/Bio/KBase/ObjectAPI/KBasePhenotypes/PhenotypeSimulationSet.pm
+++ b/lib/Bio/KBase/ObjectAPI/KBasePhenotypes/PhenotypeSimulationSet.pm
@@ -76,7 +76,7 @@ sub printTSV {
 	my  $output = ["Growth condition\tGene KO\tMedia WS\tAddtional compounds\tAddtl compound bounds\tCustom reaction bounds\tObserved normal growth\tSimulated growth\tSimulated growth fraction\tGapfilled reaction count\tGapfilled reactions\tPrediction class"];
 	my $phenotypes = $self->phenotypeSimulations();
 	for (my $i=0; $i < @{$phenotypes}; $i++) {
-		push(@{$output},$phenotypes->[$i]->phenotype()->media()->_wsname()."\t".$phenotypes->[$i]->phenotype()->geneKOString()."\t".$phenotypes->[$i]->phenotype()->media()->_wsworkspace()."\t".$phenotypes->[$i]->phenotype()->additionalCpdString()."\t".$phenotypes->[$i]->phenotype()->compoundBoundsString()."\t".$phenotypes->[$i]->phenotype()->reactionBoundsString()."\t".$phenotypes->[$i]->phenotype()->normalizedGrowth()."\t".$phenotypes->[$i]->simulatedGrowth()."\t".$phenotypes->[$i]->simulatedGrowthFraction()."\t".$phenotypes->[$i]->numGapfilledReactions()."\t".join(";",@{$phenotypes->[$i]->gapfilledReactions()})."\t".$phenotypes->[$i]->phenotype()->phenoclass()
+		push(@{$output},$phenotypes->[$i]->phenotype()->media()->_wsname()."\t".$phenotypes->[$i]->phenotype()->geneKOString()."\t".$phenotypes->[$i]->phenotype()->media()->_wsworkspace()."\t".$phenotypes->[$i]->phenotype()->additionalCpdString()."\t".$phenotypes->[$i]->phenotype()->compoundBoundsString()."\t".$phenotypes->[$i]->phenotype()->reactionBoundsString()."\t".$phenotypes->[$i]->phenotype()->normalizedGrowth()."\t".$phenotypes->[$i]->simulatedGrowth()."\t".$phenotypes->[$i]->simulatedGrowthFraction()."\t".$phenotypes->[$i]->numGapfilledReactions()."\t".join(";",@{$phenotypes->[$i]->gapfilledReactions()})."\t".$phenotypes->[$i]->phenoclass()
 );
 	}
 	if ($args->{file} == 1) {


### PR DESCRIPTION
@JamesJeffryes, @cshenry - I tested the version in prod/beta and got an error message: 'Error: Can't locate object method "phenoclass" via package "Bio::KBase::ObjectAPI::KBasePhenotypes::Phenotype" '. This change fixes the error.

Fix export to TSV and Excel. Change '$phenotypes->[$i]->phenotype()->phenoclass()' to '$phenotypes->[$i]->phenoclass()'. 