### PR TITLE
Compare models bug

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,9 @@
 
 ###Release Notes
 
+**2.2.2**
+Fixing bug in compare models
+
 **2.2.1**
 Fixing bug in community model merging app.
 

--- a/kbase.yml
+++ b/kbase.yml
@@ -8,6 +8,6 @@ service-language:
     perl
 
 module-version:
-    2.2.1
+    2.2.2
 owners:
     [chenry, jjeffryes, seaver, janakakbase, ajireland]

--- a/lib/Bio/KBase/ObjectAPI/functions.pm
+++ b/lib/Bio/KBase/ObjectAPI/functions.pm
@@ -4919,7 +4919,7 @@ sub func_compare_models {
 		eval {
 			$model = $handler->util_get_object($model_ref,{raw => 1});
 			my $output = Bio::KBase::kbaseenv::get_object_info([{"ref"=>$model_ref}],0);
-			$model->{id} = $output->[1];
+			$model->{id} = $output->[0][1];
 			print("Downloaded model: $model->{id}\n");
 			if (defined($modelnamehash->{$model->{id}})) {
 				die "Duplicate model names are not permitted\n";


### PR DESCRIPTION
There's an error in Compare Models where it says model names are duplicates, it appears because it's getting an array of len 1 with the object info inside instead of the expected object info array.